### PR TITLE
Silence a compiler warning about type mismatch

### DIFF
--- a/src/jmetrics.c
+++ b/src/jmetrics.c
@@ -92,7 +92,7 @@ float metric_mpe(const unsigned char *original, const unsigned char *compressed,
         {
             for (z = 0; z < components; z++)
             {
-                delta = abs((float)original[k] - (float)compressed[k]);
+                delta = abs(original[k] - compressed[k]);
                 pmel += delta;
                 k++;
             }


### PR DESCRIPTION
Silences a compiler warning:
```
warning: using integer absolute value function 'abs' when argument is of floating point type
```

Potential type conversion before change:

> unsigned char -> int? (int promotion?) -> float -> int (abs) -> float (delta)

After:

> unsigned char -> int (int promotion, abs) -> float (delta)

Related to https://github.com/ImageProcessing-ElectronicPublications/libsmallfry/pull/3

Test run on 24mp image:

```
$ ./jpeg-recompress-1 -m mpe test.jpg t1.jpg
Metadata size is 12kb
MPE at q=50 (1 - 99): UM 0.781268
MPE at q=26 (1 - 50): UM 0.729807
MPE at q=38 (26 - 50): UM 0.762753
MPE at q=32 (26 - 38): UM 0.748915
MPE at q=35 (32 - 38): UM 0.756064
MPE at q=34 (32 - 35): UM 0.753602
MPE at q=33 (32 - 34): UM 0.753623
Final optimized MPE at q=33: UM 0.753623
New size is 2% of original (saved 10112 kb)

$ ./jpeg-recompress-2 -m mpe test.jpg t2.jpg
Metadata size is 12kb
MPE at q=50 (1 - 99): UM 0.781268
MPE at q=26 (1 - 50): UM 0.729807
MPE at q=38 (26 - 50): UM 0.762753
MPE at q=32 (26 - 38): UM 0.748915
MPE at q=35 (32 - 38): UM 0.756064
MPE at q=34 (32 - 35): UM 0.753602
MPE at q=33 (32 - 34): UM 0.753623
Final optimized MPE at q=33: UM 0.753623
New size is 2% of original (saved 10112 kb)

$ sha256sum t?.jpg
1468197ee424a10591ff7b3cb31a3b01bf047d6107ceafa0e95c2cb914f96370  t1.jpg
1468197ee424a10591ff7b3cb31a3b01bf047d6107ceafa0e95c2cb914f96370  t2.jpg
```
